### PR TITLE
Resolve deprecation warning in PHP 8

### DIFF
--- a/src/LeafletField.php
+++ b/src/LeafletField.php
@@ -49,7 +49,7 @@ class LeafletField extends FormField
      * @param string $name The name of the field
      * @param string $title The title of the field
      */
-    public function __construct($name, $title = null, DataObject $data)
+    public function __construct($name, $title, DataObject $data)
     {
         $this->data = $data;
 


### PR DESCRIPTION
When using PHP 8 the module throws an error:
```
Deprecated: Required parameter $data follows optional parameter $title in /vendor/benmanu/silverstripe-leafletfield/src/LeafletField.php on line 52
```